### PR TITLE
Change bin name from `cargo-htmd` to `htmd`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,24 +15,21 @@ jobs:
           - release_for: Linux-x86_64
             os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
-            bin: cargo-htmd
-            bin_archived: htmd
+            bin: htmd
             name: htmd-cli-linux-x86_64.tar.gz
             command: build
 
           - release_for: Windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
-            bin: cargo-htmd.exe
-            bin_archived: htmd.exe
+            bin: htmd.exe
             name: htmd-cli-windows-x86_64.zip
             command: both
 
           - release_for: macOS-x86_64
             os: macOS-latest
             target: x86_64-apple-darwin
-            bin: cargo-htmd
-            bin_archived: htmd
+            bin: htmd
             name: htmd-cli-darwin-x86_64.tar.gz
             command: both
 
@@ -61,24 +58,13 @@ jobs:
           args: "--locked --release"
           strip: true
 
-      - name: Rename binary on Linux or macOS
-        if: runner.os != 'Windows'
-        run: |
-          mv target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }} target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin_archived }}
-
-      - name: Rename binary on Windows
-        if: runner.os == 'Windows'
-        run: |
-          Rename-Item -Path target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }} ${{ matrix.platform.bin_archived }}
-        shell: pwsh
-
       - name: Compress binary
         if: runner.os != 'Windows'
-        run: tar -czvf ${{ matrix.platform.name }} -C target/${{ matrix.platform.target }}/release ${{ matrix.platform.bin_archived }}
+        run: tar -czvf ${{ matrix.platform.name }} -C target/${{ matrix.platform.target }}/release ${{ matrix.platform.bin }}
 
       - name: Compress binary for Windows
         if: runner.os == 'Windows'
-        run: powershell Compress-Archive -Path target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin_archived }} -DestinationPath ${{ matrix.platform.name }}
+        run: powershell Compress-Archive -Path target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }} -DestinationPath ${{ matrix.platform.name }}
 
       - name: Fetch all tags
         run: git fetch --tags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ features = [
 ]
 
 [[bin]]
-name = "cargo-htmd"
+name = "htmd"
 path = "src/main.rs"

--- a/README.md
+++ b/README.md
@@ -65,17 +65,8 @@ htmd test.html --config htmd-options.toml
 
 ### Cargo
 
-Install the package
-
 ```bash
 cargo install htmd-cli
-```
-
-Use `cargo-htmd` or `cargo htmd`
-
-```bash
-cargo-htmd hello.html
-cargo htmd -i hello.html # Require explicit input option
 ```
 
 ### Binaries


### PR DESCRIPTION
As @dbohdan pointed out in #1, this tool has nothing to do with cargo, change the bin name to `htmd` to avoid confusion.