### PR TITLE
Implement stdin stdout for io, and make them default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 ### Basic
 
 ```bash
+# Read input from stdin
+htmd
+
 # Will write output to stdout
 htmd test.html
 
@@ -34,7 +37,7 @@ htmd ./pages -o converted
 
 Stdin (`-` as the filename), file, directory, and glob pattern are supported.
 
-This default input is `stdin`, so after you type only `htmd` it will wait for input, to submit typing, press <kbd>Ctrl</kbd> + <kbd>D</kbd> (<kbd>Ctrl</kbd> + <kbd>Z</kbd> on Windows).
+This default input is `stdin`, so after you type only `htmd` it will wait for input, to finish typing, press <kbd>Ctrl</kbd> + <kbd>D</kbd> (<kbd>Ctrl</kbd> + <kbd>Z</kbd> on Windows).
 
 Example inputs:
 
@@ -66,7 +69,7 @@ htmd test.html --ignored-tags "head,script,style" --heading-style setex
 By default, when converting files using glob patterns such as `pages/**/*.html`, output files will follow the original folder hierarchy, to flatten output files, use `--flatten-output`.
 
 ```bash
-htmd pages/**/*.html --output converted
+htmd pages/**/*.html --output converted --flatten-output
 ```
 
 ### Load options form toml file

--- a/README.md
+++ b/README.md
@@ -14,21 +14,46 @@
 ### Basic
 
 ```bash
-htmd test.html # Will generate test.md
-htmd --input test.html --output converted.md
+# Will write output to stdout
+htmd test.html
+
+# Explicit input option
+htmd --input test.html
+
+# Write output to test.md by shell
+htmd test.html > test.md
+
+# Write output to test.md internally
+htmd test.html --output ./
+
+# Read html files from a directory
+htmd ./pages -o converted
 ```
 
-### Folders
+### Inputs
 
-```bash
-htmd pages --output converted
-```
+Stdin (`-` as the filename), file, directory, and glob pattern are supported.
 
-### Glob patterns
+This default input is `stdin`, so after you type only `htmd` it will wait for input, to submit typing, press <kbd>Ctrl</kbd> + <kbd>D</kbd> (<kbd>Ctrl</kbd> + <kbd>Z</kbd> on Windows).
 
-```bash
-htmd pages/**/*.htm
-```
+Example inputs:
+
+- Stdin: `-`, `< page.html`
+- File: `page.html`, `index.html`
+- Directory: `pages`, `./folder`
+- Glob pattern: `pages/\*\*/\*.html`, `./\*.html`
+
+### Output
+
+Stdout (`-` as the filename), file, and directory are supported. Defaults to stdout.
+
+You cannot set output as stdout when you have multiple input files.
+
+Example outputs:
+
+- Stdout: `-`
+- File: `output.md`,
+- Directory: `output`, `./converted`
 
 ### With conversion options
 

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -110,29 +110,29 @@ pub(crate) fn cli_args() -> Vec<Arg> {
         Arg::new("input")
             .short('i')
             .long("input")
-            .help("The input. Can be stdin ('-'), file, directory, or a glob pattern; defaults to stdin")
+            .help("Specify input. Can be stdin ('-'), file, directory, or glob pattern; defaults to stdin")
             .num_args(1),
         Arg::new("output")
             .short('o')
             .long("output")
             .help(
-                "The output. Can be stdout ('-'), file, or directory; defaults to stdout",
+                "Specify output. Can be stdout ('-'), file, or directory; defaults to stdout",
             )
             .num_args(1),
         Arg::new("config")
             .long("config")
             .help(
-                "The cli options toml config file, options are within [options] section;\n\
+                "Read cli options from a toml config file. Options are within [options] section;\n\
                 if specified, other options will be ignored except for input and output",
             )
             .num_args(1),
         Arg::new("flatten-output")
             .long("flatten-output")
-            .help("Don't keep the original directory hierarchy on output files")
+            .help("Flat the output files in the output folder")
             .action(ArgAction::SetTrue),
         Arg::new("ignored-tags")
             .long("ignored-tags")
-            .help("An HTML tag list to be ignored, separated by commas")
+            .help("Set an HTML tag list to be ignored, separated by commas")
             .num_args(1),
         Arg::new("heading-style")
             .long("heading-style")
@@ -184,7 +184,7 @@ pub(crate) fn cli_args() -> Vec<Arg> {
             .value_parser(["dash", "asterisk"]),
         Arg::new("preformatted-code")
             .long("preformatted-code")
-            .help("If specified, whitespace in inline code tags will be preserved")
+            .help("Preserve whitespace in inline code tags")
             .action(ArgAction::SetTrue),
         Arg::new("version")
             .short('v')

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -110,12 +110,14 @@ pub(crate) fn cli_args() -> Vec<Arg> {
         Arg::new("input")
             .short('i')
             .long("input")
-            .help("Input file, directory or a glob pattern")
+            .help("The input. Can be stdin ('-'), file, directory, or a glob pattern; defaults to stdin")
             .num_args(1),
         Arg::new("output")
             .short('o')
             .long("output")
-            .help("Output file or directory")
+            .help(
+                "The output. Can be stdout ('-'), file, or directory; defaults to stdout",
+            )
             .num_args(1),
         Arg::new("config")
             .long("config")

--- a/src/io_util.rs
+++ b/src/io_util.rs
@@ -1,0 +1,134 @@
+use std::{
+    fs,
+    io::{self, Read},
+    path::PathBuf,
+    process::exit,
+};
+
+use clap::ArgMatches;
+use glob::glob;
+
+#[derive(PartialEq)]
+pub(crate) enum Input {
+    Stdin(String),
+    Fs(Vec<PathBuf>),
+}
+
+#[derive(PartialEq)]
+pub(crate) enum Output {
+    Stdout,
+    Fs(PathBuf),
+}
+
+pub(crate) fn resolve_input(matches: &ArgMatches) -> Input {
+    let read_stdin = || -> Input {
+        let mut text = String::new();
+        io::stdin()
+            .read_to_string(&mut text)
+            .expect("Cannot read text from stdin.");
+        Input::Stdin(text)
+    };
+
+    let input_from_arg = |id: &str| -> Option<Input> {
+        let Some(input_arg) = matches.get_one::<String>(id) else {
+            return None;
+        };
+
+        if input_arg == "-" {
+            return Some(read_stdin());
+        }
+
+        let files = get_html_files_from_input(&input_arg);
+
+        if files.is_empty() {
+            eprintln!("File or directory does not exists: {}", input_arg);
+            exit(1);
+        }
+
+        Some(Input::Fs(files))
+    };
+
+    if let Some(input) = input_from_arg("input") {
+        return input;
+    }
+
+    if let Some(input) = input_from_arg("input-unnamed") {
+        return input;
+    }
+
+    read_stdin()
+}
+
+pub(crate) fn resolve_output(matches: &ArgMatches) -> Output {
+    let Some(output) = matches.get_one::<String>("output") else {
+        return Output::Stdout;
+    };
+    if output == "-" {
+        return Output::Stdout;
+    }
+    Output::Fs(PathBuf::from(output))
+}
+
+fn get_html_files_from_input(pattern: &str) -> Vec<PathBuf> {
+    if pattern == "." || pattern == "./" {
+        // Fast path for the current dir
+        return read_dir_html_files(&std::env::current_dir().unwrap());
+    }
+    // Parse input as glob
+    let mut files: Vec<PathBuf> = Vec::new();
+    for entry in glob(pattern).expect("Failed to read input") {
+        match entry {
+            Ok(path) => {
+                let Some(ext) = path.extension() else {
+                    continue;
+                };
+                let Some(etx) = ext.to_str() else {
+                    continue;
+                };
+                let ext = etx.to_lowercase();
+                if ext == "html" || ext == "htm" {
+                    files.push(path);
+                }
+            }
+            Err(e) => eprintln!("Error while matching file: {}", e),
+        }
+    }
+    if !files.is_empty() {
+        return files;
+    }
+    // Treat the input as a file or a directory
+    let file = PathBuf::from(pattern);
+    if !file.exists() {
+        eprintln!("File or directory does not exist: {:?}", file);
+        exit(1);
+    }
+    if file.is_dir() {
+        read_dir_html_files(&file)
+    } else {
+        vec![file]
+    }
+}
+
+fn read_dir_html_files(dir: &PathBuf) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    for entry in fs::read_dir(dir).unwrap() {
+        if let Ok(entry) = entry {
+            let child = entry.path();
+            if possible_html_file(&child) {
+                files.push(child);
+            }
+        }
+    }
+    files
+}
+
+fn possible_html_file(path: &PathBuf) -> bool {
+    let Some(ext) = path.extension() else {
+        return false;
+    };
+    let Some(ext) = ext.to_str() else {
+        return false;
+    };
+    let ext = ext.to_lowercase();
+    ext == "html" || ext == "htm"
+}


### PR DESCRIPTION
As @dbohdan suggested in #2, we should implement stdin as an input, and stdout as an output, and make them default.

This can be confusing for someone with poor CLI experience (me) because if you just type "htmd" it will wait for input and not prompt you anything. But this is how other cli tools on *nix do, this will allow us to interact with other tools, such as `grep`, `cmark`, etc.

```bash
htmd < hello.html

htmd < hello.html | grep "heading"

cmark < hello.md | htmd
```

Fs input and output still work the same way, but stdout as the output won't work when your input has multiple files.